### PR TITLE
V0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.5.0
 
+- **BREAKING CHANGE**: replace use of [querystring](https://nodejs.org/api/querystring.html) with [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
 - add `cookies()` middleware
 - cleanup documentation
 - add optional `TBody` type parameter to `IHttpRequest` interface to describe body property

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log (@egomobile/http-server)
 
+## 0.5.0
+
+- add `cookies()` middleware
+- cleanup documentation
+- add optional `TBody` type parameter to `IHttpRequest` interface to describe body property
+- `npm update`
+
 ## 0.4.0
 
 - add `validate()` middleware

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.5.0
 
 - **BREAKING CHANGE**: replace use of [querystring](https://nodejs.org/api/querystring.html) with [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
-- add `cookies()` middleware
+- add `cookies()` and `lang()` middlewares
 - cleanup documentation
 - add optional `TBody` type parameter to `IHttpRequest` interface to describe body property
 - `npm update`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,28 @@ async function main() {
 main().catch(console.error);
 ```
 
+#### cookies
+
+```typescript
+import createServer, { cookies } from "@egomobile/http-server";
+
+async function main() {
+  // ...
+
+  // parses the content of 'Cookie' HTTP header
+  // and makes it available as key/value pairs
+  // in 'cookies' property of 'request' object
+  app.delete("/", [cookies()], async (request, response) => {
+    response.write(" FOO: " + request.cookies!.foo);
+    response.write(" BAZ: " + request.cookies!.baz);
+  });
+
+  // ...
+}
+
+main().catch(console.error);
+```
+
 #### 3rd party modules
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ async function main() {
 main().catch(console.error);
 ```
 
+#### lang
+
+```typescript
+import createServer, { lang } from "@egomobile/http-server";
+
+async function main() {
+  // ...
+
+  // parses the content of 'Accept-Language' HTTP header
+  // and makes the best matching, supported language available
+  // in 'lang' property of 'request' object
+  app.get("/docs", [lang("de", "en")], async (request, response) => {
+    response.write("lang: " + request.lang);
+  });
+
+  // ...
+}
+
+main().catch(console.error);
+```
+
 #### 3rd party modules
 
 ```typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1226,9 +1226,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.20.22",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.22.tgz",
-            "integrity": "sha512-P87zMpHfn4/8LRmY3jm3b9oWsQ9wMe5Wnx5MuRqE6C832Wqnoz5Agh0/eIQ5WywvdlI+VJU6F92s1dl3ScD5ig=="
+            "version": "12.20.23",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.23.tgz",
+            "integrity": "sha512-FW0q7NI8UnjbKrJK8NGr6QXY69ATw9IFe6ItIo5yozPwA9DU/xkhiPddctUVyrmFXvyFYerYgQak/qu200UBDw=="
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Very fast alternative HTTP server to Express, with simple routing and middleware support and which is compatible with Node.js 12 or later.",
     "main": "lib/index.js",
     "engines": {
@@ -53,7 +53,7 @@
         "README.md"
     ],
     "dependencies": {
-        "@types/node": "^12.20.22",
+        "@types/node": "^12.20.23",
         "joi": "^17.4.2",
         "regexparam": "^2.0.0"
     },

--- a/src/__tests__/cookies.test.ts
+++ b/src/__tests__/cookies.test.ts
@@ -1,0 +1,58 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import request from 'supertest';
+import { cookies } from '../middlewares';
+import { HttpRequestPath, IHttpRequest, IHttpResponse } from '../types';
+import { binaryParser, createServer } from './utils';
+
+const routePaths: HttpRequestPath[] = [
+    '/',
+    (request) => request.url === '/',
+    /^(\/)$/i
+];
+
+describe('Simple request with cookies', () => {
+    ['get', 'delete', 'options', 'patch', 'put', 'post', 'trace'].forEach(method => {
+        const methodName = method.toUpperCase();
+
+        it.each(routePaths)(`should return 200 when do a ${methodName} request with a 'bar' query parameter in URL`, async (path) => {
+            const expectedResult = 'object:foo=bar;baz=MKTM';
+
+            const server = createServer();
+
+            (server as any)[method](path, [cookies()], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write(
+                    `${typeof req.cookies}:foo=${req.cookies!.foo};baz=${req.cookies!.baz}`
+                );
+            });
+
+            const response = await (request(server) as any)[method]('/')
+                .set('Cookie', 'foo=bar; baz=MKTM')
+                .send()
+                .parse(binaryParser)
+                .expect(200);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString('utf8');
+
+            expect(typeof str).toBe('string');
+            expect(str.length).toBe(expectedResult.length);
+            expect(str).toBe(expectedResult);
+        });
+    });
+});

--- a/src/__tests__/lang.test.ts
+++ b/src/__tests__/lang.test.ts
@@ -1,0 +1,81 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import request from 'supertest';
+import { lang } from '../middlewares';
+import { HttpRequestPath, IHttpRequest, IHttpResponse } from '../types';
+import { binaryParser, createServer } from './utils';
+
+const routePaths: HttpRequestPath[] = [
+    '/',
+    (request) => request.url === '/',
+    /^(\/)$/i
+];
+
+describe('Simple request with Accept-Language header', () => {
+    ['get', 'delete', 'options', 'patch', 'put', 'post', 'trace'].forEach(method => {
+        const methodName = method.toUpperCase();
+
+        it.each(routePaths)(`should return 200 with 'de' as result when do a ${methodName} request with a supported language`, async (path) => {
+            const expectedResult = 'de';
+
+            const server = createServer();
+
+            (server as any)[method](path, [lang('en', 'de')], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write(req.lang);
+            });
+
+            const response = await (request(server) as any)[method]('/')
+                .set('Accept-Language', 'de, en-GB;q=0.85, en;q=0.9')
+                .send()
+                .parse(binaryParser)
+                .expect(200);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString('utf8');
+
+            expect(typeof str).toBe('string');
+            expect(str.length).toBe(expectedResult.length);
+            expect(str).toBe(expectedResult);
+        });
+
+        it.each(routePaths)(`should return 200 with 'en' as default result when do a ${methodName} request with an unsupported language`, async (path) => {
+            const expectedResult = 'en';
+
+            const server = createServer();
+
+            (server as any)[method](path, [lang('en', 'de')], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write(req.lang);
+            });
+
+            const response = await (request(server) as any)[method]('/')
+                .set('Accept-Language', 'ru, en-GB;q=0.85, en;q=0.9')
+                .send()
+                .parse(binaryParser)
+                .expect(200);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString('utf8');
+
+            expect(typeof str).toBe('string');
+            expect(str.length).toBe(expectedResult.length);
+            expect(str).toBe(expectedResult);
+        });
+    });
+});

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -23,13 +23,13 @@ describe('Simple request with url query parameters', () => {
         const methodName = method.toUpperCase();
 
         it(`should return 200 when do a ${methodName} request with a 'bar' query parameter in URL`, async () => {
-            const expectedResult = 'object:bar=baz;baz=undefined';
+            const expectedResult = 'object:bar=baz;baz=null';
 
             const server = createServer();
 
             (server as any)[method]('/foo', [query()], async (req: IHttpRequest, resp: IHttpResponse) => {
                 resp.write(
-                    `${typeof req.query}:bar=${req.query!.bar};baz=${req.query!.baz}`
+                    `${typeof req.query}:bar=${req.query!.get('bar')};baz=${req.query!.get('baz')}`
                 );
             });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,6 +430,7 @@ export {
 
 export {
     buffer,
+    cookies,
     defaultBodyLimit,
     defaultLimitReachedHandler,
     defaultParseErrorHandler,

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,10 +435,11 @@ export {
     defaultLimitReachedHandler,
     defaultParseErrorHandler,
     defaultValidationFailedHandler,
-    json,
     IBufferOptions,
     IJsonOptions,
     IValidateOptions,
+    json,
+    lang,
     query,
     validate
 } from './middlewares';

--- a/src/middlewares/buffer.ts
+++ b/src/middlewares/buffer.ts
@@ -46,13 +46,13 @@ interface ICreateMiddlewareOptions {
  * const app = createServer()
  *
  * async function handleLimitReached(request: IHttpRequest, response: IHttpResponse) {
- *     request.writeHead(400)
- *     request.write('Input is too big')
+ *   request.writeHead(400)
+ *   request.write('Input is too big')
  * }
  *
  * // maximum input size: 128 MB
  * app.post('/', buffer(), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(Buffer.isBuffer(request.body), true)
+ *   assert.strictEqual(Buffer.isBuffer(request.body), true)
  * })
  *
  * // maximum input size: 256 MB
@@ -62,14 +62,14 @@ interface ICreateMiddlewareOptions {
  *
  * // maximum input size: 384 MB
  * app.patch('/', buffer({ limit: 402653184 }), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(Buffer.isBuffer(request.body), true)
+ *   assert.strictEqual(Buffer.isBuffer(request.body), true)
  * })
  *
  * // custom error handler
  * app.delete('/', buffer({ limit: 1048576, onLimitReached: handleLimitReached }), async (request: IHttpRequest, response: IHttpResponse) => {
  * // alternative:
  * // app.delete('/', buffer(1, handleLimitReached), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(Buffer.isBuffer(request.body), true)
+ *   assert.strictEqual(Buffer.isBuffer(request.body), true)
  * })
  * ```
  */

--- a/src/middlewares/cookies.ts
+++ b/src/middlewares/cookies.ts
@@ -1,0 +1,70 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import { HttpMiddleware } from '../types';
+
+/**
+ * Creates a new middleware that parses submitted cookies
+ * into 'cookies' property of request context as key/value pairs.
+ *
+ * @example
+ * ```
+ * import assert from 'assert'
+ * import createServer, { IHttpRequest, IHttpResponse, cookies } from '@egomobile/http-server'
+ *
+ * const app = createServer()
+ *
+ * // try submit 'cookie' HTTP header
+ * // with 'foo=bar; baz=MKTM'
+ * app.get('/', [cookies()], async (request: IHttpRequest, response: IHttpResponse) => {
+ *   assert.strictEqual(request.cookies!.foo, 'bar')
+ *   assert.strictEqual(request.cookies!.baz, 'MKTM')
+ * })
+ *
+ * await app.listen()
+ * ```
+ *
+ * @returns {HttpMiddleware} The new middleware.
+ */
+export function cookies(): HttpMiddleware {
+    return async (request, response, next) => {
+        request.cookies = {};
+
+        if (typeof request.headers['cookie'] === 'string') {
+            const cookieList = request.headers['cookie']
+                .split(';')
+                .map(c => c.trim())
+                .filter(c => c !== '');
+
+            for (const c of cookieList) {
+                let name: string;
+                let value: string;
+
+                const sep = c.indexOf('=');
+                if (sep > -1) {
+                    name = c.substr(0, sep);
+                    value = c.substr(sep + 1);
+                } else {
+                    name = c;
+                    value = '';
+                }
+
+                request.cookies[name.trim()] = value;
+            }
+        }
+
+        next();
+    };
+}

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -73,5 +73,6 @@ export const defaultValidationFailedHandler: ValidationFailedHandler = async (er
 export * from './buffer';
 export * from './cookies';
 export * from './json';
+export * from './lang';
 export * from './query';
 export * from './validate';

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -71,6 +71,7 @@ export const defaultValidationFailedHandler: ValidationFailedHandler = async (er
 };
 
 export * from './buffer';
+export * from './cookies';
 export * from './json';
 export * from './query';
 export * from './validate';

--- a/src/middlewares/json.ts
+++ b/src/middlewares/json.ts
@@ -53,30 +53,30 @@ export interface IJsonOptions extends IHttpBodyParserOptions {
  * const app = createServer()
  *
  * async function handleLimitReached(request: IHttpRequest, response: IHttpResponse) {
- *     request.writeHead(400)
- *     request.write('Input is too big')
+ *   request.writeHead(400)
+ *   request.write('Input is too big')
  * }
  *
  * // maximum input size: 128 MB
  * app.post('/', json(), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(typeof request.body, 'object')
+ *   assert.strictEqual(typeof request.body, 'object')
  * })
  *
  * // maximum input size: 256 MB
  * app.put('/', json(256), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(typeof request.body, 'object')
+ *   assert.strictEqual(typeof request.body, 'object')
  * })
  *
  * // maximum input size: 384 MB
  * app.patch('/', json({ limit: 402653184 }), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(typeof request.body, 'object')
+ *   assert.strictEqual(typeof request.body, 'object')
  * })
  *
  * // custom error handler
  * app.delete('/', json({ limit: 1048576, onLimitReached: handleLimitReached }), async (request: IHttpRequest, response: IHttpResponse) => {
  * // alternative:
  * // app.delete('/', json(1, handleLimitReached), async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(typeof request.body, 'object')
+ *   assert.strictEqual(typeof request.body, 'object')
  * })
  * ```
  */

--- a/src/middlewares/lang.ts
+++ b/src/middlewares/lang.ts
@@ -1,0 +1,109 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import type { HttpMiddleware, Nilable } from '../types';
+
+interface ICreateMiddlewareOptions {
+    additionalLanguages: string[];
+    defaultLanguage: string;
+}
+
+/**
+ * Creates a middleware, that tries to get the current language from
+ * 'Accept-Language' HTTP header and writes it to 'lang' property
+ * of request context.
+ *
+ * @param {string} defaultLanguage The default language.
+ * @param {string[]} additionalLanguages The list of additional, supported languages.
+ *
+ * @returns {HttpMiddleware} The new middleware.
+ *
+ * @example
+ * ```
+ * import assert from 'assert'
+ * import createServer, { IHttpRequest, IHttpResponse, lang } from '@egomobile/http-server'
+ *
+ * const app = createServer()
+ *
+ * // try submit 'Accept-Language' HTTP header
+ * // with 'de, en-GB;q=0.85, en;q=0.9'
+ * app.get('/', [lang('de', 'en')], async (request, response) => {
+ *   assert.strictEqual(request.lang, 'de')
+ * })
+ * ```
+ */
+export function lang(defaultLanguage: string, ...additionalLanguages: string[]): HttpMiddleware {
+    if (typeof defaultLanguage !== 'string') {
+        throw new TypeError('defaultLanguage must be of type string');
+    }
+
+    if (!Array.isArray(additionalLanguages)) {
+        throw new TypeError('additionalLanguages must be of type Array');
+    }
+
+    if (!additionalLanguages.every(sl => typeof sl === 'string')) {
+        throw new TypeError('All items of additionalLanguages must be of type string');
+    }
+
+    return createMiddleware({
+        additionalLanguages: additionalLanguages.map(asl => asl.toLowerCase().trim()),
+        defaultLanguage: defaultLanguage.toLowerCase().trim()
+    });
+}
+
+function createMiddleware({ additionalLanguages, defaultLanguage }: ICreateMiddlewareOptions): HttpMiddleware {
+    return async (request, response, next) => {
+        let lang: Nilable<string>;
+
+        try {
+            if (typeof request.headers['accept-language'] === 'string') {
+                // parse 'Accept-Language' header
+                // example: Accept-Language: de, en-GB;q=0.85, en;q=0.9
+                const acceptLanguage = request.headers['accept-language']
+                    .split(',')
+                    .map(x => {
+                        let lang: string;
+                        let weight = 1;
+
+                        const sep = x.indexOf(';');
+                        if (sep > -1) {
+                            lang = x.substr(0, sep);
+
+                            const weightExpr = x.substr(sep + 1);
+                            const q = weightExpr.indexOf('q=');
+                            if (q > -1) {
+                                weight = parseFloat(weightExpr.substr(q + 2).trim());
+                            }
+                        } else {
+                            lang = x;
+                        }
+
+                        return {
+                            lang: lang.toLowerCase().trim(),
+                            weight
+                        };
+                    });
+
+                lang = acceptLanguage
+                    .sort((a, b) => b.weight - a.weight)  // DESC
+                    .find(al => additionalLanguages.includes(al.lang))?.lang;
+            }
+        } catch { }
+
+        request.lang = lang?.length ? lang : defaultLanguage;
+
+        next();
+    };
+}

--- a/src/middlewares/query.ts
+++ b/src/middlewares/query.ts
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import querystring from 'querystring';
 import type { HttpMiddleware } from '../types';
 
 /**
@@ -30,7 +29,7 @@ import type { HttpMiddleware } from '../types';
  *
  * // try to access via: /?foo=bar
  * app.get('/', [query()], async (request: IHttpRequest, response: IHttpResponse) => {
- *   assert.strictEqual(typeof request.query!.foo, 'string')
+ *   assert.strictEqual(typeof request.query!.get('foo'), 'string')
  * })
  *
  * await app.listen()
@@ -40,8 +39,6 @@ import type { HttpMiddleware } from '../types';
  */
 export function query(): HttpMiddleware {
     return async (request, response, next) => {
-        request.query = {};
-
         try {
             if (request.url?.length) {
                 let qs = '';
@@ -52,10 +49,14 @@ export function query(): HttpMiddleware {
                 }
 
                 if (qs.length) {
-                    request.query = querystring.parse(qs);
+                    request.query = new URLSearchParams(qs);
                 }
             }
         } catch { }
+
+        if (!request.query) {
+            request.query = new URLSearchParams();
+        }
 
         next();
     };

--- a/src/middlewares/query.ts
+++ b/src/middlewares/query.ts
@@ -30,7 +30,7 @@ import type { HttpMiddleware } from '../types';
  *
  * // try to access via: /?foo=bar
  * app.get('/', [query()], async (request: IHttpRequest, response: IHttpResponse) => {
- *     assert.strictEqual(typeof request.query!.foo, 'string')
+ *   assert.strictEqual(typeof request.query!.foo, 'string')
  * })
  *
  * await app.listen()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,6 @@
 
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { ValidationError as JoiValidationError } from 'joi';
-import type { ParsedUrlQuery } from 'querystring';
 import type { ParseError } from '../errors/parse';
 
 /**
@@ -118,7 +117,7 @@ export interface IHttpRequest<TBody extends any = any> extends IncomingMessage {
     /**
      * List of query parameters, if parsed.
      */
-    query?: ParsedUrlQuery;
+    query?: URLSearchParams;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,11 +106,15 @@ export interface IHttpRequestHandlerOptions {
 /**
  * A HTTP request.
  */
-export interface IHttpRequest extends IncomingMessage {
+export interface IHttpRequest<TBody extends any = any> extends IncomingMessage {
     /**
      * The body, if parsed.
      */
-    body?: any;
+    body?: TBody;
+    /**
+     * List of cookies, if parsed.
+     */
+    cookies?: Record<string, string>;
     /**
      * List of query parameters, if parsed.
      */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,10 @@ export interface IHttpRequest<TBody extends any = any> extends IncomingMessage {
      */
     cookies?: Record<string, string>;
     /**
+     * The current language, if parsed.
+     */
+    lang?: Nullable<string>;
+    /**
      * List of query parameters, if parsed.
      */
     query?: URLSearchParams;


### PR DESCRIPTION
- **BREAKING CHANGE**: replace use of [querystring](https://nodejs.org/api/querystring.html) with [URLSearchParams](https://nodejs.org/api/url.html#url_class_urlsearchparams)
- add `cookies()` and `lang()` middlewares
- cleanup documentation
- add optional `TBody` type parameter to `IHttpRequest` interface to describe body property
- `npm update`