### PR TITLE
made key param of Import() decorator optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log (@egomobile/http-server)
 
+## 0.27.0
+
+- `key` parameter of [@Import() decorator](https://egomobile.github.io/node-http-server/modules.html#Import) is now optional, what means that, if no key is submitted, the name of the underlying property is used
+
 ## 0.26.1
 
 - add [@Import() decorator](https://egomobile.github.io/node-http-server/modules.html#Import), which can import values into a controller's property or provide them there

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.26.1",
+    "version": "0.27.0",
     "description": "Very fast alternative HTTP server to Express, with simple routing and middleware support and which is compatible with Node.js 12 or later.",
     "main": "lib/index.js",
     "engines": {

--- a/src/__tests__/controllers/test7/index.ts
+++ b/src/__tests__/controllers/test7/index.ts
@@ -6,7 +6,7 @@ export default class Test7Controller extends ControllerBase {
     @Import('foo')
     public foo!: string;
 
-    @Import('baz')
+    @Import()
     public baz!: number;
 
     @GET('/')

--- a/src/controllers/Import.ts
+++ b/src/controllers/Import.ts
@@ -60,7 +60,7 @@ export function Import(key?: Nilable<ObjectKey>): PropertyDecorator {
                 const lazyValue = (imports as any)[valueKey];
 
                 if (typeof lazyValue === 'undefined') {
-                    throw new TypeError(`Import value ${String(key)} not found`);
+                    throw new TypeError(`Import value ${String(valueKey)} not found`);
                 }
 
                 // setup the property with a getter

--- a/src/controllers/Import.ts
+++ b/src/controllers/Import.ts
@@ -2,7 +2,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { SETUP_IMPORTS } from '../constants';
-import { InitControllerImportAction, ObjectKey } from '../types/internal';
+import type { InitControllerImportAction, Nilable, ObjectKey } from '../types/internal';
+import { isNil } from '../utils';
 import { getListFromObject } from './utils';
 
 /**
@@ -17,15 +18,15 @@ import { getListFromObject } from './utils';
  *
  * @Controller()
  * export default class MyController extends ControllerBase {
- *   @Import('foo')  // s. [1]
- *   public fooValue!: string
+ *   @Import()  // s. [1]
+ *   public foo!: string
  *
  *   @Import('currentTime')  // s. [2]
  *   public now!: Date
  *
  *   @GET()
  *   async index(request: IHttpRequest, response: IHttpResponse) {
- *     response.write(this.fooValue + ': ' + this.now)
+ *     response.write(this.foo + ': ' + this.now)
  *   }
  * }
  *
@@ -46,15 +47,17 @@ import { getListFromObject } from './utils';
  * app.listen()
  * ```
  *
- * @param {ObjectKey} key The key.
+ * @param {Nilable<ObjectKey>} [key] The key. Default: The name of the underlying property.
  *
  * @returns {PropertyDecorator} The new decorator function.
  */
-export function Import(key: ObjectKey): PropertyDecorator {
+export function Import(key?: Nilable<ObjectKey>): PropertyDecorator {
     return function (target, propertyName) {
+        const valueKey = isNil(key) ? propertyName : key!;
+
         getListFromObject<InitControllerImportAction>(target, SETUP_IMPORTS).push(
             ({ controller, imports }) => {
-                const lazyValue = (imports as any)[key];
+                const lazyValue = (imports as any)[valueKey];
 
                 if (typeof lazyValue === 'undefined') {
                     throw new TypeError(`Import value ${String(key)} not found`);


### PR DESCRIPTION
- `key` parameter of [@Import() decorator](https://egomobile.github.io/node-http-server/modules.html#Import) is now optional, what means that, if no key is submitted, the name of the underlying property is used