### PR TITLE
implement validation with Swagger / Open API schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Swagger documents are validated with [openapi-schema-validator module](https://www.npmjs.com/package/openapi-schema-validator) by default now ... this behavior can be changed, updating [validate property](https://egomobile.github.io/node-http-server/interfaces/IControllersSwaggerOptions.html#document)
 - implement `validateWithSwagger()` middleware and its representations inside the controller framework, like [@GET()](https://egomobile.github.io/node-http-server/modules.html#GET) or [@POST()](https://egomobile.github.io/node-http-server/modules.html#POST) decorators
 - code cleanups and improvements
+- (bug-)fixes
 
 ## 0.36.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log (@egomobile/http-server)
 
+## 0.37.0
+
+- Swagger documents are validated with [openapi-schema-validator module](https://www.npmjs.com/package/openapi-schema-validator) by default now ... this behavior can be changed, updating [validate property](https://egomobile.github.io/node-http-server/interfaces/IControllersSwaggerOptions.html#document)
+
 ## 0.36.1
 
 - implement `@BodyParseErrorHandler()` decorator to handle parse errors in combination with [schema validation, configured by decorators](https://github.com/egomobile/node-http-server/wiki/Controllers#validate-input)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Swagger documents are validated with [openapi-schema-validator module](https://www.npmjs.com/package/openapi-schema-validator) by default now ... this behavior can be changed, updating [validate property](https://egomobile.github.io/node-http-server/interfaces/IControllersSwaggerOptions.html#document)
 - implement `validateWithSwagger()` middleware and its representations inside the controller framework, like [@GET()](https://egomobile.github.io/node-http-server/modules.html#GET) or [@POST()](https://egomobile.github.io/node-http-server/modules.html#POST) decorators
+- code cleanups and improvements
 
 ## 0.36.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.37.0
 
 - Swagger documents are validated with [openapi-schema-validator module](https://www.npmjs.com/package/openapi-schema-validator) by default now ... this behavior can be changed, updating [validate property](https://egomobile.github.io/node-http-server/interfaces/IControllersSwaggerOptions.html#document)
+- implement `validateWithSwagger()` middleware and its representations inside the controller framework, like [@GET()](https://egomobile.github.io/node-http-server/modules.html#GET) or [@POST()](https://egomobile.github.io/node-http-server/modules.html#POST) decorators
 
 ## 0.36.1
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The module makes use of:
 - [regexparam](https://github.com/lukeed/regexparam) by
   [Luke Edwards](https://github.com/lukeed)
 - [Swagger UI](https://github.com/swagger-api/swagger-ui) and
-  [openapi-types](https://github.com/kogosoftwarellc/open-api)
+  [@open-api](https://github.com/kogosoftwarellc/open-api)
 
 <a name="documentation"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1370,6 +1370,32 @@
                 "fast-json-stable-stringify": "^2.0.0",
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "requires": {
+                "ajv": "^8.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
             }
         },
         "ansi-align": {
@@ -2917,8 +2943,7 @@
         "fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-glob": {
             "version": "3.2.11",
@@ -4590,8 +4615,7 @@
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "lowercase-keys": {
             "version": "1.0.1",
@@ -4970,6 +4994,35 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "openapi-schema-validator": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.0.0.tgz",
+            "integrity": "sha512-dtQ5iCiCluL/SXmd5LWqfPXvN/WbVJeCp+3+exF6BHBN3fry5tNAhFllZICYHQ2kTfQxrfwbQcy0fqaw9wOb+w==",
+            "requires": {
+                "ajv": "^8.1.0",
+                "ajv-formats": "^2.0.2",
+                "lodash.merge": "^4.6.1",
+                "openapi-types": "^12.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
+            }
+        },
         "openapi-types": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
@@ -5184,8 +5237,7 @@
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "pupa": {
             "version": "2.1.1",
@@ -5395,6 +5447,11 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "resolve": {
             "version": "1.22.0",
@@ -6225,7 +6282,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,6 +1933,11 @@
                 }
             }
         },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+        },
         "convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -4994,6 +4999,45 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "openapi-jsonschema-parameters": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-12.0.0.tgz",
+            "integrity": "sha512-OqPabvo3qEUpgG2blD+CqAUNC+/RNYsUKEqY3vSAu2syxrabRNxtaagLhA5WdieVQPLFuOlSX13TFUu8R/+kbA==",
+            "requires": {
+                "openapi-types": "^12.0.0"
+            }
+        },
+        "openapi-request-validator": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-12.0.0.tgz",
+            "integrity": "sha512-z0K3fRViKbamg80RJgNLzLZik2QBvXVfHgtpK4nGlTQ7qgn06PApFzF1Arc4Fb3aAB26BFBQGzjrojT58XjA3A==",
+            "requires": {
+                "ajv": "^8.3.0",
+                "ajv-formats": "^2.1.0",
+                "content-type": "^1.0.4",
+                "openapi-jsonschema-parameters": "^12.0.0",
+                "openapi-types": "^12.0.0",
+                "ts-log": "^2.1.4"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
+            }
+        },
         "openapi-schema-validator": {
             "version": "12.0.0",
             "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.0.0.tgz",
@@ -5962,6 +6006,11 @@
                     }
                 }
             }
+        },
+        "ts-log": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+            "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ=="
         },
         "ts-node": {
             "version": "10.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.36.2",
+    "version": "0.37.0",
     "description": "Very fast alternative HTTP server to Express, with simple routing and middleware support and which is compatible with Node.js 12 or later.",
     "main": "lib/index.js",
     "engines": {
@@ -58,6 +58,7 @@
         "joi": "17.6.0",
         "js-yaml": "4.1.0",
         "minimatch": "5.1.0",
+        "openapi-schema-validator": "12.0.0",
         "openapi-types": "12.0.0",
         "swagger-ui-dist": "4.12.0"
     },

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "joi": "17.6.0",
         "js-yaml": "4.1.0",
         "minimatch": "5.1.0",
+        "openapi-request-validator": "12.0.0",
         "openapi-schema-validator": "12.0.0",
         "openapi-types": "12.0.0",
         "swagger-ui-dist": "4.12.0"

--- a/src/__tests__/controllers.swagger.test.ts
+++ b/src/__tests__/controllers.swagger.test.ts
@@ -1,0 +1,89 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import request from "supertest";
+import { URLSearchParams } from "url";
+import { binaryParser, createServerAndInitControllers } from "./utils";
+
+const validData: any[] = [{
+    "foo": ""
+}, {
+    "foo": "bar"
+}];
+
+const invalidData: any[] = [{}, {
+    "bar": "0"
+}];
+
+function toQueryString(obj: any): string {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(obj)) {
+        params.set(key, String(value));
+    }
+
+    return params.toString();
+}
+
+describe("Swagger validation feature tests (controllers)", () => {
+    ["get"].forEach(method => {
+        const methodName = method.toUpperCase();
+
+        it.each(validData)(`should return 200 when do a ${methodName} request and send valid query params`, async (vd) => {
+            const resultText = "ok";
+
+            const server = createServerAndInitControllers();
+
+            const response = await (request(server) as any)[method]("/test_swagger/test1?" + toQueryString(vd))
+                .send(JSON.stringify(vd))
+                .parse(binaryParser)
+                .expect(200);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString("utf8");
+
+            expect(typeof str).toBe("string");
+            expect(str.length).toBe(resultText.length);
+            expect(str).toBe(resultText);
+        });
+
+        it.each(invalidData)(`should return 400 when do a ${methodName} request and send invalid query params`, async (ivd) => {
+            const server = createServerAndInitControllers();
+
+            await (request(server) as any)[method]("/test_swagger/test1?" + toQueryString(ivd))
+                .send(JSON.stringify(ivd))
+                .parse(binaryParser)
+                .expect(400);
+        });
+
+        it.each(invalidData)(`should return 403 when do a ${methodName} request and send invalid query params and a custom handler`, async (ivd) => {
+            const server = createServerAndInitControllers();
+
+            const response = await (request(server) as any)[method]("/test_swagger/test2?" + toQueryString(ivd))
+                .send(JSON.stringify(ivd))
+                .parse(binaryParser)
+                .expect(403);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString("utf8");
+
+            expect(typeof str).toBe("string");
+            expect(str.length > 0).toBe(true);
+        });
+    });
+});

--- a/src/__tests__/controllers/test_swagger/index.ts
+++ b/src/__tests__/controllers/test_swagger/index.ts
@@ -1,0 +1,60 @@
+import { Controller, IHttpRequest, IHttpResponse, JsonSchemaValidationFailedHandler } from "../../..";
+import { ControllerBase, GET } from "../../../controllers";
+
+const onValidationWithDocumentationFailed: JsonSchemaValidationFailedHandler = async (errors, req, resp) => {
+    const errorMessage = Buffer.from(
+        errors.map((error) => {
+            return error.message;
+        }).join(", "),
+        "utf8"
+    );
+
+    if (!resp.headersSent) {
+        resp.writeHead(403, {
+            "Content-Length": String(errorMessage.length)
+        });
+    }
+
+    resp.write(errorMessage);
+    resp.end();
+};
+
+@Controller()
+export default class TestSwaggerController extends ControllerBase {
+    @GET({
+        "path": "/test1",
+        "documentation": {
+            "parameters": [
+                {
+                    "in": "query",
+                    "name": "foo",
+                    "required": true
+                }
+            ],
+            "responses": {}
+        },
+        "validateWithDocumentation": true
+    })
+    async test1(request: IHttpRequest, response: IHttpResponse) {
+        response.write("ok");
+    }
+
+    @GET({
+        "path": "/test2",
+        "documentation": {
+            "parameters": [
+                {
+                    "in": "query",
+                    "name": "foo",
+                    "required": true
+                }
+            ],
+            "responses": {}
+        },
+        onValidationWithDocumentationFailed,
+        "validateWithDocumentation": true
+    })
+    async test2(request: IHttpRequest, response: IHttpResponse) {
+        response.write("ok");
+    }
+}

--- a/src/__tests__/validateWithSwagger.test.ts
+++ b/src/__tests__/validateWithSwagger.test.ts
@@ -1,0 +1,132 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import type { OpenAPIV3 } from "openapi-types";
+import request from "supertest";
+import { URLSearchParams } from "url";
+import { query, validateWithSwagger } from "../middlewares";
+import { IHttpRequest, IHttpResponse, JsonSchemaValidationFailedHandler } from "../types";
+import { binaryParser, createServer } from "./utils";
+
+const validData: any[] = [{
+    "foo": ""
+}, {
+    "foo": "bar"
+}];
+
+const invalidData: any[] = [{}, {
+    "bar": "0"
+}];
+
+const documentation: OpenAPIV3.OperationObject = {
+    "parameters": [
+        {
+            "in": "query",
+            "name": "foo",
+            "required": true
+        }
+    ],
+    "responses": {}
+};
+
+function toQueryString(obj: any): string {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(obj)) {
+        params.set(key, String(value));
+    }
+
+    return params.toString();
+}
+
+describe("validateWithSwagger.test() middleware", () => {
+    ["get", "delete", "options", "patch", "put", "post", "trace"].forEach(method => {
+        const methodName = method.toUpperCase();
+
+        it.each(validData)(`should return 200 when do a ${methodName} request and send valid query params`, async (vd) => {
+            const server = createServer();
+            const resultText = "ok";
+
+            (server as any)[method]("/", [query(), validateWithSwagger({ documentation })], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write("ok");
+            });
+
+            const response = await (request(server) as any)[method]("/?" + toQueryString(vd))
+                .send(JSON.stringify(vd))
+                .parse(binaryParser)
+                .expect(200);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString("utf8");
+
+            expect(typeof str).toBe("string");
+            expect(str.length).toBe(resultText.length);
+            expect(str).toBe(resultText);
+        });
+
+        it.each(invalidData)(`should return 400 when do a ${methodName} request and send invalid query params`, async (ivd) => {
+            const server = createServer();
+
+            (server as any)[method]("/", [query(), validateWithSwagger({ documentation })], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write("ok");
+            });
+
+            await (request(server) as any)[method]("/?" + toQueryString(ivd))
+                .send(JSON.stringify(ivd))
+                .parse(binaryParser)
+                .expect(400);
+        });
+
+        it.each(invalidData)(`should return 403 when do a ${methodName} request and send invalid query params and a custom handler`, async (ivd) => {
+            const server = createServer();
+
+            const onValidationFailed: JsonSchemaValidationFailedHandler = async (errors, req, resp) => {
+                const errorMessage = Buffer.from(
+                    errors.map((error) => {
+                        return error.message;
+                    }).join(", "),
+                    "utf8"
+                );
+
+                if (!resp.headersSent) {
+                    resp.writeHead(403, {
+                        "Content-Length": String(errorMessage.length)
+                    });
+                }
+
+                resp.write(errorMessage);
+                resp.end();
+            };
+
+            (server as any)[method]("/", [query(), validateWithSwagger({ documentation, onValidationFailed })], async (req: IHttpRequest, resp: IHttpResponse) => {
+                resp.write("ok");
+            });
+
+            const response = await (request(server) as any)[method]("/?" + toQueryString(ivd))
+                .send(JSON.stringify(ivd))
+                .parse(binaryParser)
+                .expect(403);
+
+            const data = response.body;
+            expect(Buffer.isBuffer(data)).toBe(true);
+
+            const str = data.toString("utf8");
+
+            expect(typeof str).toBe("string");
+            expect(str.length > 0).toBe(true);
+        });
+    });
+});

--- a/src/controllers/utils/index.ts
+++ b/src/controllers/utils/index.ts
@@ -93,3 +93,7 @@ export function normalizeRouterPath(p: Nilable<string>): string {
 }
 
 export * from "./authorize";
+export * from "./parameters";
+export * from "./schema";
+export * from "./swagger";
+

--- a/src/controllers/utils/parameters.ts
+++ b/src/controllers/utils/parameters.ts
@@ -1,0 +1,220 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import type { IHttpRequest, IHttpResponse, IParameterOptionsWithHeadersSource, IParameterOptionsWithQueriesSource, IParameterOptionsWithUrlsSource, ParameterDataTransformer, ParameterDataTransformTo } from "../../types";
+import type { IControllerMethodParameter, Nilable } from "../../types/internal";
+import { asAsync, createObjectNameListResolver, isNil, urlSearchParamsToObject } from "../../utils";
+
+export interface IParameterValueUpdaterContext {
+    args: any[];
+    request: IHttpRequest;
+    response: IHttpResponse;
+}
+
+export interface IToParameterDataTransformerWithValidatorOptions {
+    transformTo: Nilable<ParameterDataTransformTo>;
+}
+
+export type ParameterValueUpdater = (context: IParameterValueUpdaterContext) => Promise<any>;
+
+export function toParameterValueUpdaters(parameters: IControllerMethodParameter[]): ParameterValueUpdater[] {
+    const updaters: ParameterValueUpdater[] = [];
+
+    parameters.forEach((p) => {
+        const { index, name, options } = p;
+        const source = options.source?.toLowerCase().trim() ?? "";
+        const transformTo: Nilable<ParameterDataTransformTo> = (options as any).transformTo;
+
+        if (source === "body") {
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                args[index] = await transformer({
+                    request, response,
+                    "source": request.body
+                });
+            });
+        }
+        else if (source === "header") {
+            const headerName = name.toLowerCase().trim();
+
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                args[index] = await transformer({
+                    request, response,
+                    "source": request.headers[headerName]
+                });
+            });
+        }
+        else if (source === "headers") {
+            const headerNames: string[] = ((options as IParameterOptionsWithHeadersSource).names ?? [])
+                .map((name) => {
+                    return name.toLowerCase().trim();
+                });
+
+            const getNames = createObjectNameListResolver(headerNames);
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                const headers: any = {};
+                for (const key of getNames(request.headers)) {
+                    headers[key] = await transformer({
+                        key,
+                        request, response,
+                        "source": request.headers[key]
+                    });
+                }
+
+                args[index] = headers;
+            });
+        }
+        else if (source === "queries") {
+            const queryParamNames: string[] = [
+                ...((options as IParameterOptionsWithQueriesSource).names ?? [])
+            ];
+
+            const getNames = createObjectNameListResolver(queryParamNames);
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                const queryParams: any = urlSearchParamsToObject(request.query);
+
+                const query: any = {};
+                for (const key of getNames(queryParams)) {
+                    query[key] = await transformer({
+                        key,
+                        request, response,
+                        "source": queryParams![key]
+                    });
+                }
+
+                args[index] = query;
+            });
+        }
+        else if (source === "query") {
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                args[index] = await transformer({
+                    request, response,
+                    "source": request.query?.get(name)
+                });
+            });
+        }
+        else if (source === "request") {
+            updaters.push(async ({ args, request }) => {
+                args[index] = request;
+            });
+        }
+        else if (source === "response") {
+            updaters.push(async ({ args, response }) => {
+                args[index] = response;
+            });
+        }
+        else if (source === "urls") {
+            const urlParamNames: string[] = [
+                ...((options as IParameterOptionsWithUrlsSource).names ?? [])
+            ];
+
+            const getNames = createObjectNameListResolver(urlParamNames);
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                const params: any = {};
+                for (const key of getNames(request.params)) {
+                    params[key] = await transformer({
+                        key,
+                        request, response,
+                        "source": request.params![key]
+                    });
+                }
+
+                args[index] = params;
+            });
+        }
+        else if (["", "url"].includes(source)) {
+            const transformer = toParameterDataTransformerSafe({ transformTo });
+
+            updaters.push(async ({ args, request, response }) => {
+                args[index] = await transformer({
+                    request, response,
+                    "source": request.params?.[name]
+                });
+            });
+        }
+        else {
+            throw new TypeError(`Source of type ${source} is not supported`);
+        }
+    });
+
+    return updaters;
+}
+
+export function toParameterDataTransformerSafe({
+    transformTo
+}: IToParameterDataTransformerWithValidatorOptions): ParameterDataTransformer {
+    let transformer: Nilable<ParameterDataTransformer>;
+
+    if (isNil(transformTo)) {
+        transformer = async ({ source }) => {
+            return source;
+        };
+    }
+    else {
+        if (transformTo === "bool") {
+            transformer = async ({ source }) => {
+                return Boolean(String(source ?? "").toLowerCase().trim());
+            };
+        }
+        else if (transformTo === "buffer") {
+            transformer = async ({ source }) => {
+                if (Buffer.isBuffer(source)) {
+                    return source;
+                }
+
+                if (isNil(source)) {
+                    return Buffer.alloc(0);
+                }
+
+                return Buffer.from(String(source ?? ""), "utf8");
+            };
+        }
+        else if (transformTo === "int") {
+            transformer = async ({ source }) => {
+                return parseInt(String(source ?? "").trim());
+            };
+        }
+        else if (transformTo === "float") {
+            transformer = async ({ source }) => {
+                return parseFloat(String(source ?? "").trim());
+            };
+        }
+        else if (transformTo === "string") {
+            transformer = async ({ source }) => {
+                return String(source ?? "");
+            };
+        }
+        else if (typeof transformTo === "function") {
+            transformer = transformTo;
+        }
+    }
+
+    if (typeof transformer !== "function") {
+        throw new TypeError("transformTo must be of type function or a valid constant");
+    }
+
+    return asAsync<ParameterDataTransformer>(transformer);
+}

--- a/src/controllers/utils/schema.ts
+++ b/src/controllers/utils/schema.ts
@@ -1,0 +1,77 @@
+import { createBodyParserMiddlewareByFormat } from ".";
+import { PARSE_ERROR_HANDLER, VALIDATION_ERROR_HANDLER } from "../../constants";
+import { defaultParseErrorHandler, defaultValidationFailedHandler, json, validate } from "../../middlewares";
+import { HttpInputDataFormat, HttpMiddleware, IControllerRouteWithBodyOptions, IControllersOptions, IHttpController, IHttpServer, ValidationFailedHandler } from "../../types";
+import { Nilable } from "../../types/internal";
+import { asAsync, isNil } from "../../utils";
+
+export interface ISetupMiddlewaresByJoiSchemaOptions {
+    controller: IHttpController<IHttpServer>;
+    decoratorOptions: Nilable<IControllerRouteWithBodyOptions>;
+    globalOptions: Nilable<IControllersOptions>;
+    middlewares: HttpMiddleware[];
+    throwIfOptionsIncompatibleWithHTTPMethod: () => any;
+}
+
+function createWrappedValidationErrorHandler(handler: Nilable<ValidationFailedHandler>): Nilable<ValidationFailedHandler> {
+    if (isNil(handler)) {
+        return handler;
+    }
+
+    handler = asAsync<ValidationFailedHandler>(handler);
+
+    return async (error, request, response) => {
+        await handler!(error, request, response);
+
+        response.end();
+    };
+}
+
+export function setupMiddlewaresByJoiSchema({
+    controller,
+    decoratorOptions,
+    globalOptions,
+    middlewares,
+    throwIfOptionsIncompatibleWithHTTPMethod
+}: ISetupMiddlewaresByJoiSchemaOptions) {
+    if (!decoratorOptions?.schema) {
+        return;
+    }
+
+    throwIfOptionsIncompatibleWithHTTPMethod();
+
+    const validationErrorHandler =
+        createWrappedValidationErrorHandler(
+            decoratorOptions.onValidationFailed ||
+            (controller as any)[VALIDATION_ERROR_HANDLER] ||
+            globalOptions?.onSchemaValidationFailed
+        ) || defaultValidationFailedHandler;
+
+    const parseErrorHandler = (
+        decoratorOptions.onParsingFailed ||
+        (controller as any)[PARSE_ERROR_HANDLER] ||
+        globalOptions?.onParsingFailed
+    ) || defaultParseErrorHandler;
+
+    const createDataParser: () => HttpMiddleware = isNil(decoratorOptions?.format) ?
+        () => {
+            return json({
+                "limit": decoratorOptions.limit,
+                "onParsingFailed": parseErrorHandler
+            });
+        } :
+        () => {
+            return createBodyParserMiddlewareByFormat(decoratorOptions.format || HttpInputDataFormat.JSON, {
+                "limit": decoratorOptions.limit,
+                "onParsingFailed": parseErrorHandler
+            });
+        };
+
+    middlewares.push(
+        createDataParser(),
+        validate(decoratorOptions.schema, {
+            "onValidationFailed": validationErrorHandler
+        })
+    );
+}
+

--- a/src/controllers/utils/swagger.ts
+++ b/src/controllers/utils/swagger.ts
@@ -1,0 +1,145 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import type { OpenAPIV3 } from "openapi-types";
+import { getListFromObject } from ".";
+import { DOCUMENTATION_UPDATER, HTTP_METHODS, INIT_CONTROLLER_METHOD_SWAGGER_ACTIONS, ROUTER_PATHS, SWAGGER_METHOD_INFO } from "../../constants";
+import { validateWithSwagger } from "../../middlewares";
+import { toSwaggerPath } from "../../swagger/utils";
+import type { DocumentationUpdaterHandler, HttpMethod, HttpMiddleware, IControllerRouteWithBodyOptions, IControllersOptions } from "../../types";
+import { InitControllerMethodSwaggerAction, ISwaggerMethodInfo, Nilable } from "../../types/internal";
+import { isNil, sortObjectByKeys } from "../../utils";
+
+interface ICreateInitControllerMethodSwaggerActionOptions {
+    doc: OpenAPIV3.OperationObject;
+    method: Function;
+    methodName: string | symbol;
+};
+
+export interface ISetupMiddlewaresBySwaggerDocumentationOptions {
+    decoratorOptions: Nilable<IControllerRouteWithBodyOptions>;
+    globalOptions: Nilable<IControllersOptions>;
+    middlewares: HttpMiddleware[];
+    throwIfOptionsIncompatibleWithHTTPMethod: () => any;
+}
+
+export interface ISetupSwaggerDocumentationOptions {
+    decoratorOptions: Nilable<IControllerRouteWithBodyOptions>;
+    method: Function;
+    methodName: string | symbol;
+}
+
+function createInitControllerMethodSwaggerAction({ doc, method, methodName }: ICreateInitControllerMethodSwaggerActionOptions): InitControllerMethodSwaggerAction {
+    return ({ apiDocument, controller }) => {
+        const info: ISwaggerMethodInfo = {
+            doc,
+            method
+        };
+
+        (method as any)[SWAGGER_METHOD_INFO] = info;
+
+        const routerPaths: Nilable<string[]> = (method as any)[ROUTER_PATHS];
+        if (routerPaths?.length) {
+            const httpMethods: Nilable<HttpMethod[]> = (method as any)[HTTP_METHODS];
+
+            let paths = apiDocument.paths!;
+
+            if (httpMethods?.length) {
+                routerPaths.forEach(routerPath => {
+                    const swaggerPath = toSwaggerPath(routerPath);
+
+                    httpMethods!.forEach(httpMethod => {
+                        let pathObj: any = paths[swaggerPath];
+                        if (!pathObj) {
+                            pathObj = {};
+                        }
+
+                        let methodObj: any = pathObj[httpMethod];
+                        if (methodObj) {
+                            throw new Error(`Cannot reset documentation for route ${routerPath} (${httpMethod.toUpperCase()})`);
+                        }
+
+                        const docUpdater: Nilable<DocumentationUpdaterHandler> = (controller as any)[DOCUMENTATION_UPDATER];
+                        if (docUpdater) {
+                            docUpdater({
+                                "documentation": doc,
+                                "method": httpMethod.toUpperCase() as Uppercase<HttpMethod>,
+                                "path": routerPath
+                            });
+                        }
+
+                        pathObj[httpMethod] = doc;
+
+                        paths[swaggerPath] = sortObjectByKeys(pathObj);
+                    });
+                });
+            }
+
+            apiDocument.paths = sortObjectByKeys(paths);
+        }
+    };
+}
+
+export function setupMiddlewaresBySwaggerDocumentation({
+    decoratorOptions,
+    globalOptions,
+    middlewares
+}: ISetupMiddlewaresBySwaggerDocumentationOptions) {
+    const documentation = decoratorOptions?.documentation;
+    if (!documentation) {
+        return;
+    }
+
+    let shouldValidateWithDocumentation = false;
+    if (isNil(decoratorOptions.validateWithDocumentation)) {
+        shouldValidateWithDocumentation = !!globalOptions?.validateWithDocumentation;
+    }
+    else {
+        shouldValidateWithDocumentation = !!decoratorOptions.validateWithDocumentation;
+    }
+
+    if (!shouldValidateWithDocumentation) {
+        return;
+    }
+
+    const onValidationFailed = decoratorOptions.onValidationWithDocumentationFailed ||
+        globalOptions?.onValidationWithDocumentationFailed;
+
+    // first add 'validateWithSwagger()' middleware
+    middlewares.push(validateWithSwagger({
+        documentation,
+        onValidationFailed
+    }));
+}
+
+export function setupSwaggerDocumentation({
+    decoratorOptions,
+    method,
+    methodName
+}: ISetupSwaggerDocumentationOptions) {
+    if (!decoratorOptions?.documentation) {
+        return;
+    }
+
+    getListFromObject<InitControllerMethodSwaggerAction>(method, INIT_CONTROLLER_METHOD_SWAGGER_ACTIONS).push(
+        createInitControllerMethodSwaggerAction({
+            "doc": JSON.parse(
+                JSON.stringify(decoratorOptions.documentation)
+            ),
+            method,
+            methodName
+        })
+    );
+}

--- a/src/controllers/utils/swagger.ts
+++ b/src/controllers/utils/swagger.ts
@@ -95,7 +95,8 @@ function createInitControllerMethodSwaggerAction({ doc, method, methodName }: IC
 export function setupMiddlewaresBySwaggerDocumentation({
     decoratorOptions,
     globalOptions,
-    middlewares
+    middlewares,
+    throwIfOptionsIncompatibleWithHTTPMethod
 }: ISetupMiddlewaresBySwaggerDocumentationOptions) {
     const documentation = decoratorOptions?.documentation;
     if (!documentation) {
@@ -112,6 +113,10 @@ export function setupMiddlewaresBySwaggerDocumentation({
 
     if (!shouldValidateWithDocumentation) {
         return;
+    }
+
+    if ((documentation.requestBody as OpenAPIV3.RequestBodyObject)?.required) {
+        throwIfOptionsIncompatibleWithHTTPMethod();
     }
 
     const onValidationFailed = decoratorOptions.onValidationWithDocumentationFailed ||

--- a/src/errors/swaggerValidation.ts
+++ b/src/errors/swaggerValidation.ts
@@ -13,19 +13,20 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import type { GetStatusCodeFromError } from "../types";
-
 /**
- * The default handler, that returns the HTTP status code by error object.
- *
- * @returns {number} 500
+ * Describes an Swagger validation error.
  */
-export const defaultGetStatusCodeFromError: GetStatusCodeFromError = () => {
-    return 500;
-};
-
-export * from "./authorize";
-export * from "./entityTooLarge";
-export * from "./parse";
-export * from "./swaggerValidation";
-
+export class SwaggerValidationError extends Error {
+    /**
+     * Initializes a new instance of that class.
+     *
+     * @param {string} [message] The custom message.
+     * @param {any} [innerError] The inner error.
+     */
+    public constructor(
+        message?: string,
+        public readonly innerError?: any
+    ) {
+        super(message);
+    }
+}

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -27,7 +27,7 @@ export const defaultBodyLimit = 134217728;
  * @param {IncomingMessage} request The request context.
  * @param {ServerResponse} response The response context.
  */
-export const defaultJsonValidationFailedHandler: JsonSchemaValidationFailedHandler = async (errors, request, response) => {
+export const defaultJsonSchemaValidationFailedHandler: JsonSchemaValidationFailedHandler = async (errors, request, response) => {
     if (!response.headersSent) {
         response.writeHead(400, {
             "Content-Length": "0"

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -13,12 +13,27 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import type { HttpRequestHandler, ParseErrorHandler, ValidationFailedHandler } from "../types";
+import type { HttpRequestHandler, JsonSchemaValidationFailedHandler, ParseErrorHandler, ValidationFailedHandler } from "../types";
 
 /**
  * Default limit of a body parser: 128 MB
  */
 export const defaultBodyLimit = 134217728;
+
+/**
+ * The default 'parse error' handler.
+ *
+ * @param {IJsonSchemaError[]} errors The error.
+ * @param {IncomingMessage} request The request context.
+ * @param {ServerResponse} response The response context.
+ */
+export const defaultJsonValidationFailedHandler: JsonSchemaValidationFailedHandler = async (errors, request, response) => {
+    if (!response.headersSent) {
+        response.writeHead(400, {
+            "Content-Length": "0"
+        });
+    }
+};
 
 /**
  * The default 'body limit reached' handler.
@@ -50,7 +65,7 @@ export const defaultParseErrorHandler: ParseErrorHandler = async (error, request
 };
 
 /**
- * The default 'parse error' handler.
+ * The default 'query validation error' handler.
  *
  * @param {ParseError} error The error.
  * @param {IncomingMessage} request The request context.
@@ -65,7 +80,7 @@ export const defaultQueryValidationFailedHandler: ValidationFailedHandler = asyn
 };
 
 /**
- * The default 'parse error' handler.
+ * The default 'schema validation error' handler.
  *
  * @param {ParseError} error The error.
  * @param {IncomingMessage} request The request context.
@@ -90,5 +105,6 @@ export * from "./query";
 export * from "./text";
 export * from "./validate";
 export * from "./validateQuery";
+export * from "./validateWithSwagger";
 export * from "./yaml";
 

--- a/src/middlewares/validateWithSwagger.ts
+++ b/src/middlewares/validateWithSwagger.ts
@@ -15,7 +15,7 @@
 
 import OpenAPIRequestValidator, { OpenAPIRequestValidatorArgs } from "openapi-request-validator";
 import type { OpenAPIV3 } from "openapi-types";
-import { defaultJsonValidationFailedHandler } from ".";
+import { defaultJsonSchemaValidationFailedHandler } from ".";
 import type { HttpMiddleware, JsonSchemaValidationFailedHandler } from "../types";
 import { Nilable } from "../types/internal";
 import { asAsync, urlSearchParamsToObject } from "../utils";
@@ -84,7 +84,7 @@ export function validateWithSwagger(options: IValidateWithSwaggerOptions): HttpM
         throw new TypeError("options must be of type object");
     }
 
-    const onValidationFailed = options.onValidationFailed || defaultJsonValidationFailedHandler;
+    const onValidationFailed = options.onValidationFailed || defaultJsonSchemaValidationFailedHandler;
     if (typeof onValidationFailed !== "function") {
         throw new TypeError("options.onValidationFailed must be of type function");
     }

--- a/src/middlewares/validateWithSwagger.ts
+++ b/src/middlewares/validateWithSwagger.ts
@@ -1,0 +1,123 @@
+// This file is part of the @egomobile/http-server distribution.
+// Copyright (c) Next.e.GO Mobile SE, Aachen, Germany (https://e-go-mobile.com/)
+//
+// @egomobile/http-server is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation, version 3.
+//
+// @egomobile/http-server is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import OpenAPIRequestValidator, { OpenAPIRequestValidatorArgs } from "openapi-request-validator";
+import type { OpenAPIV3 } from "openapi-types";
+import { defaultJsonValidationFailedHandler } from ".";
+import type { HttpMiddleware, JsonSchemaValidationFailedHandler } from "../types";
+import { Nilable } from "../types/internal";
+import { asAsync, urlSearchParamsToObject } from "../utils";
+
+interface ICreateMiddlewareOptions {
+    documentation: OpenAPIV3.OperationObject;
+    onValidationFailed: JsonSchemaValidationFailedHandler;
+}
+
+/**
+ * Options for 'validateWithSwagger()' function.
+ */
+export interface IValidateWithSwaggerOptions {
+    /**
+     * The documentation to use as schema for the validation.
+     */
+    documentation: OpenAPIV3.OperationObject;
+    /**
+     * The custom error handler.
+     */
+    onValidationFailed?: Nilable<JsonSchemaValidationFailedHandler>;
+}
+
+/**
+ * Creates a new middleware, which checks the request data with
+ * a Swagger documentation for an endpoint.
+ *
+ * @example
+ * ```
+ * import createServer, { IHttpRequest, IHttpResponse, query, schema, validateWithSwagger } from '@egomobile/http-server'
+ * import type { OpenAPIV3.OperationObject } from 'openapi-types'
+ *
+ * const swaggerDocumentOfGetRequest: OpenAPIV3.OperationObject = {
+ *   "parameters": [
+ *     {
+ *       in: 'query',
+ *       name: 'foo',
+ *       required: true
+ *     },
+ *     "responses": {}
+ *   ]
+ * }
+ *
+ * const app = createServer()
+ *
+ * app.get(
+ *   '/',
+ *   [
+ *     query(),
+ *     validateWithSwagger(swaggerDocumentOfGetRequest)
+ *   ],
+ *   async (request, response) => {
+ *     assert.strictEqual(typeof request.query!.get('foo'), 'string')
+ *   }
+ * )
+ *
+ * // ...
+ * ```
+ *
+ * @param {IValidateWithSwaggerOptions} options The options.
+ *
+ * @returns {HttpMiddleware} The new middleware.
+ */
+export function validateWithSwagger(options: IValidateWithSwaggerOptions): HttpMiddleware {
+    if (typeof options !== "object") {
+        throw new TypeError("options must be of type object");
+    }
+
+    const onValidationFailed = options.onValidationFailed || defaultJsonValidationFailedHandler;
+    if (typeof onValidationFailed !== "function") {
+        throw new TypeError("options.onValidationFailed must be of type function");
+    }
+
+    return createMiddleware({
+        "documentation": options.documentation,
+        "onValidationFailed": asAsync<JsonSchemaValidationFailedHandler>(onValidationFailed)
+    });
+}
+
+function createMiddleware({ documentation, onValidationFailed }: ICreateMiddlewareOptions): HttpMiddleware {
+    return async (request, response, next) => {
+        const validatorArgs: OpenAPIRequestValidatorArgs = {
+            "parameters": documentation.parameters ?? undefined,
+            "requestBody": (documentation.requestBody as OpenAPIV3.RequestBodyObject) ?? undefined
+        };
+
+        const validator = new OpenAPIRequestValidator(validatorArgs);
+
+        const validationResult = validator.validateRequest({
+            "headers": request.headers,
+            "body": request.body,
+            "params": request.params ?? undefined,
+            "query": urlSearchParamsToObject(request.query) ?? undefined
+        });
+
+        if (!validationResult?.errors?.length) {
+            next();
+        }
+        else {
+            await onValidationFailed(validationResult.errors, request, response);
+
+            response.end();
+        }
+    };
+}

--- a/src/middlewares/validateWithSwagger.ts
+++ b/src/middlewares/validateWithSwagger.ts
@@ -45,7 +45,7 @@ export interface IValidateWithSwaggerOptions {
  *
  * @example
  * ```
- * import createServer, { IHttpRequest, IHttpResponse, query, schema, validateWithSwagger } from '@egomobile/http-server'
+ * import createServer, { query, validateWithSwagger } from '@egomobile/http-server'
  * import type { OpenAPIV3.OperationObject } from 'openapi-types'
  *
  * const swaggerDocumentOfGetRequest: OpenAPIV3.OperationObject = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1142,16 +1142,6 @@ export interface IHttpServer {
 }
 
 /**
- * A list of import values.
- */
-export type ImportValues = Record<ObjectKey, LazyImportValue>;
-
-/**
- * A (lazy) value.
- */
-export type LazyImportValue<T extends any = any> = T | (() => T);
-
-/**
  * Options for a body parser function, that works with string data.
  */
 export interface IHttpStringBodyParserOptions extends IHttpBodyParserOptions {
@@ -1159,6 +1149,33 @@ export interface IHttpStringBodyParserOptions extends IHttpBodyParserOptions {
      * The custom string encoding to use. Default: utf8
      */
     encoding?: Nilable<BufferEncoding>;
+}
+
+/**
+ * A list of import values.
+ */
+export type ImportValues = Record<ObjectKey, LazyImportValue>;
+
+/**
+ * A error item for a `JsonSchemaValidationFailedHandler` handler.
+ */
+export interface IJsonSchemaError {
+    /**
+     * The error code.
+     */
+    errorCode: string;
+    /**
+     * The location.
+     */
+    location: string;
+    /**
+     * The message.
+     */
+    message: string;
+    /**
+     * The path.
+     */
+    path: string;
 }
 
 /**
@@ -1316,6 +1333,20 @@ export interface ISwaggerInitializedEventArguments {
      */
     documentation: OpenAPIV3.Document;
 }
+
+/**
+ * A handler, which is invoked, when a JSON schema validation fails.
+ *
+ * @param {IJsonSchemaError[]} errors The list of errors.
+ * @param {IHttpRequest} request The request context.
+ * @param {IHttpResponse} response The response context.
+ */
+export type JsonSchemaValidationFailedHandler = (errors: IJsonSchemaError[], request: IHttpRequest, response: IHttpResponse) => any;
+
+/**
+ * A (lazy) value.
+ */
+export type LazyImportValue<T extends any = any> = T | (() => T);
 
 /**
  * A next function.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -553,6 +553,12 @@ export interface IControllersSwaggerOptions {
      * The base document.
      */
     document: ControllersSwaggerBaseDocument;
+    /**
+     * Validate output document or not.
+     *
+     * @default true
+     */
+    validate?: Nilable<boolean>;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -406,6 +406,10 @@ export interface IControllerRouteOptions {
      */
     onError?: Nilable<HttpErrorHandler>;
     /**
+     * The handler, that is executed, when object validation with Swagger documentation failed.
+     */
+    onValidationWithDocumentationFailed?: Nilable<JsonSchemaValidationFailedHandler>;
+    /**
      * The custom path.
      */
     path?: Nilable<ControllerRoutePath>;
@@ -417,6 +421,12 @@ export interface IControllerRouteOptions {
      * One or more middlewares for the route.
      */
     use?: Nilable<HttpMiddleware | HttpMiddleware[]>;
+    /**
+     * Validate request data with schema in `documentation` or not.
+     *
+     * @default false
+     */
+    validateWithDocumentation?: Nilable<boolean>;
 }
 
 /**
@@ -526,6 +536,10 @@ export interface IControllersOptions {
      */
     onSwaggerInitialized?: Nilable<SwaggerInitializedEventHandler>;
     /**
+     * The default handler, that is executed, when object validation with Swagger documentation failed.
+     */
+    onValidationWithDocumentationFailed?: Nilable<JsonSchemaValidationFailedHandler>;
+    /**
      * The custom file patterns.
      *
      * @see https://www.npmjs.com/package/minimatch
@@ -539,6 +553,13 @@ export interface IControllersOptions {
      * Options to setup Swagger UI.
      */
     swagger?: Nilable<ControllersSwaggerOptionsValue>;
+    /**
+     * Default, which indicates, to validate request data with schema in `documentation` prop
+     * of a request decorator like `@GET()` or `@POST()` or not.
+     *
+     * @default false
+     */
+    validateWithDocumentation?: Nilable<boolean>;
 }
 
 /**


### PR DESCRIPTION
# CHANGELOG

- Swagger documents are validated with [openapi-schema-validator module](https://www.npmjs.com/package/openapi-schema-validator) by default now ... this behavior can be changed, updating [validate property](https://egomobile.github.io/node-http-server/interfaces/IControllersSwaggerOptions.html#document)
- implement `validateWithSwagger()` middleware and its representations inside the controller framework, like [@GET()](https://egomobile.github.io/node-http-server/modules.html#GET) or [@POST()](https://egomobile.github.io/node-http-server/modules.html#POST) decorators
- code cleanups and improvements
- (bug-)fixes

## Validation examples

### Use in controllers

```typescript
import { Controller, ControllerBase, GET, IHttpRequest, IHttpResponse } from "@egomobile/http-server";

@Controller()
export default class TestSwaggerController extends ControllerBase {
    @GET({
        "path": "/test1",
        "documentation": {
            "parameters": [
                {
                    "in": "query",
                    "name": "foo",
                    "required": true
                }
            ],
            "responses": {}
        },
        "validateWithDocumentation": true
    })
    async test1(request: IHttpRequest, response: IHttpResponse) {
        response.write("ok");
    }
}
```

### Example with simple middleware

```typescript
import createServer, { query, validateWithSwagger } from '@egomobile/http-server'
import type { OpenAPIV3.OperationObject } from 'openapi-types'

const swaggerDocumentOfGetRequest: OpenAPIV3.OperationObject = {
  "parameters": [
    {
      in: 'query',
      name: 'foo',
      required: true
    },
    "responses": {}
  ]
}

const app = createServer()

app.get(
  '/',
  [
    query(),
    validateWithSwagger(swaggerDocumentOfGetRequest)
  ],
  async (request, response) => {
    assert.strictEqual(typeof request.query!.get('foo'), 'string')
  }
)

// ...
```