### PR TITLE
load swagger documentation paths automatically from .openapi files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log (@egomobile/http-server)
 
+## 0.43.0
+
+- add `loadOpenAPIFiles` to [IControllerMethodInfo](https://egomobile.github.io/node-http-server/interfaces/IControllerMethodInfo.html), which can load resources for a Swagger document, organized in `.openapi` files
+
 ## 0.42.2
 
 - add `resourcePath` to [IControllerMethodInfo](https://egomobile.github.io/node-http-server/interfaces/IControllerMethodInfo.html), which can load resources for a Swagger document, organized in a strict structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.42.2",
+    "version": "0.43.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@egomobile/http-server",
-            "version": "0.42.2",
+            "version": "0.43.0",
             "license": "LGPL-3.0",
             "dependencies": {
                 "@types/json-schema": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.42.2",
+    "version": "0.43.0",
     "description": "Very fast alternative HTTP server to Express, with simple routing and middleware support and which is compatible with Node.js 12 or later.",
     "main": "lib/index.js",
     "engines": {

--- a/src/swagger/utils.ts
+++ b/src/swagger/utils.ts
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import type { OpenAPIV3 } from "openapi-types";
 import { normalizeRouterPath } from "../controllers/utils";
 import type { HttpPathValidator } from "../types";
 import type { Nilable } from "../types/internal";
@@ -24,7 +25,7 @@ export function createSwaggerPathValidator(basePath: Nilable<string>): HttpPathV
 
     return (request) => {
         return request.url === basePath ||
-        !!request.url?.startsWith(basePathWithSuffix);
+            !!request.url?.startsWith(basePathWithSuffix);
     };
 }
 
@@ -51,4 +52,16 @@ export function toSwaggerPath(routePath: string): string {
             })
             .join("/")
     );
+}
+
+export function toOperationObject(val: unknown): Nilable<OpenAPIV3.OperationObject> {
+    if (typeof val === "function") {
+        return val();
+    }
+
+    if (typeof val === "object" || isNil(val)) {
+        return val as Nilable<OpenAPIV3.OperationObject>;
+    }
+
+    throw new TypeError("val must be of type function or object");
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -735,7 +735,7 @@ export interface IControllersSwaggerOptions {
      */
     document: ControllersSwaggerBaseDocument;
     /**
-     * Tries to load endpoint documentation from `.openapi` files. 
+     * Tries to load endpoint documentation from `.openapi` files.
      *
      * @default true
      */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -735,6 +735,12 @@ export interface IControllersSwaggerOptions {
      */
     document: ControllersSwaggerBaseDocument;
     /**
+     * Tries to load endpoint documentation from `.openapi` files. 
+     *
+     * @default true
+     */
+    loadOpenAPIFiles?: Nilable<boolean>;
+    /**
      * Value, which indicates, if all endpoints should have documentation or not.
      *
      * @default true


### PR DESCRIPTION
- add `loadOpenAPIFiles` to [IControllerMethodInfo](https://egomobile.github.io/node-http-server/interfaces/IControllerMethodInfo.html), which can load resources for a Swagger document, organized in `.openapi` files