### PR TITLE
multi test declarations and templating for test names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log (@egomobile/http-server)
 
+## 0.46.0
+
+- `name` on [@It() decorator](https://egomobile.github.io/node-http-server/functions/It.html) now supports templating with the following placeholders:
+  - `{{body}}`: expected body
+  - `{{header:my-header}}`: expected value for header `my-header`
+  - `{{parameter:myParameter}}`: submitted value of URL parameter `myParameter`
+  - `{{status}}`: expected HTTP status code
+- can implement / declare multiple tests / test settings in `.spec` files now
+- add `groupIndex` and `ref` props to [ITestEventHandlerContext interface](https://egomobile.github.io/node-http-server/interfaces/ITestEventHandlerContext.html)
+- add `ref` prop to [ITestSettings interface](https://egomobile.github.io/node-http-server/interfaces/ITestSettings.html)
+
 ## 0.45.0
 
 - add `isUIEnabled` property to [ISwaggerInitializedEventArguments interface](https://egomobile.github.io/node-http-server/interfaces/ISwaggerInitializedEventArguments.html)

--- a/README.md
+++ b/README.md
@@ -223,15 +223,18 @@ import {
 @Describe("My controller")
 export default class MyController extends ControllerBase {
   @GET("/foo/:bar")
-  @It("should return BUZZ in code with status 202", {
-    expectations: {
-      body: "BUZZ",
-      status: 202,
-    },
-    parameters: {
-      bar: "buzz",
-    },
-  })
+  @It(
+    "should return '{{body}}' in body with status {{status}} when submitting parameter {{parameter:bar}}",
+    {
+      expectations: {
+        body: "BUZZ",
+        status: 202,
+      },
+      parameters: {
+        bar: "buzz",
+      },
+    }
+  )
   async index(request: IHttpRequest, response: IHttpResponse) {
     response.writeHead(202);
     response.write(request.params!.bar.toUpperCase());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.45.0",
+    "version": "0.46.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@egomobile/http-server",
-            "version": "0.45.0",
+            "version": "0.46.0",
             "license": "LGPL-3.0",
             "dependencies": {
                 "@types/json-schema": "7.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@egomobile/http-server",
-    "version": "0.45.0",
+    "version": "0.46.0",
     "description": "Very fast alternative HTTP server to Express, with simple routing and middleware support and which is compatible with Node.js 12 or later.",
     "main": "lib/index.js",
     "engines": {

--- a/src/controllers/factories.ts
+++ b/src/controllers/factories.ts
@@ -1002,15 +1002,16 @@ export function setupHttpServerControllerMethod(setupOptions: ISetupHttpServerCo
 
                 // (unit-)tests
                 getListFromObject<InitControllerMethodTestAction>(propValue, ADD_CONTROLLER_METHOD_TEST_ACTION).forEach((action) => {
+                    const index = numberOfTests++;
+
                     action({
                         controller,
+                        index,
                         server,
                         "shouldAllowEmptySettings": !!options?.allowEmptyTestSettings,
                         "shouldUseModuleAsDefault": shouldUseTestModuleAsDefault,
                         "timeout": testTimeout
                     });
-
-                    ++numberOfTests;
                 });
 
                 // tell, that controller method has been initialized

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1643,6 +1643,10 @@ export interface ITestEventHandlerContext {
      */
     group: string;
     /**
+     * The zero-based index of the current test, inside the `group`.
+     */
+    groupIndex: number;
+    /**
      * HTTP request headers.
      */
     headers: Record<string, string>;
@@ -1662,6 +1666,10 @@ export interface ITestEventHandlerContext {
      * Gets or sets a function, which listens for a cancellation event.
      */
     onCancellationRequested: Nilable<TestEventCancellationEventHandler>;
+    /**
+     * A reference value.
+     */
+    ref: any;
     /**
      * The path of the route with possible parameters.
      */
@@ -1742,6 +1750,11 @@ export interface ITestSettings {
      * URL parameters.
      */
     parameters?: Nilable<TestSettingValueOrGetter<Record<string, string>>>;
+    /**
+     * This is an explicit reference to the underlying test,
+     * declared by things like `@It()` decorator.
+     */
+    ref?: any;
     /**
      * Custom timeout value in ms.
      */

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -100,6 +100,7 @@ export interface IInitControllerParseErrorHandlerActionContext {
 
 export interface IInitControllerMethodTestActionContext {
     controller: IHttpController<IHttpServer>;
+    index: number;
     server: IHttpServer;
     shouldAllowEmptySettings: boolean;
     shouldUseModuleAsDefault: boolean;
@@ -176,6 +177,7 @@ export interface ITestOptions {
     getHeaders: (context: ITestSettingValueGetterContext) => Promise<Record<string, any>>;
     getParameters: (context: ITestSettingValueGetterContext) => Promise<Record<string, string>>;
     getTimeout: (context: ITestSettingValueGetterContext) => Promise<number>;
+    index: number;
     method: Function;
     methodName: string | symbol;
     name: string;


### PR DESCRIPTION
- `name` on [@It() decorator](https://egomobile.github.io/node-http-server/functions/It.html) now supports templating with the following placeholders:
  - `{{body}}`: expected body
  - `{{header:my-header}}`: expected value for header `my-header`
  - `{{parameter:myParameter}}`: submitted value of URL parameter `myParameter`
  - `{{status}}`: expected HTTP status code
- can implement / declare multiple tests / test settings in `.spec` files now
- add `groupIndex` and `ref` props to [ITestEventHandlerContext interface](https://egomobile.github.io/node-http-server/interfaces/ITestEventHandlerContext.html)
- add `ref` prop to [ITestSettings interface](https://egomobile.github.io/node-http-server/interfaces/ITestSettings.html)